### PR TITLE
Removing Stray Div for tags

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -9,7 +9,6 @@
          
         {{with .Params.LastModifierDisplayName}}
             <i class='fa fa-user'></i> <a href="mailto:{{ $.Params.LastModifierEmail }}">{{ . }}</a> {{with $.Date}} <i class='fa fa-calendar'></i> {{ .Format "02/01/2006" }}{{end}}
-            </div>
         {{end}}
 
         


### PR DESCRIPTION
This seems to be a stray div tag that causes tags to be misaligned as follows:

![misalignedtags](https://cloud.githubusercontent.com/assets/7731709/26538267/6fb995e2-43fa-11e7-8cdf-d668db6f50f9.png)

When removed:

![alignedtgs](https://cloud.githubusercontent.com/assets/7731709/26538285/9513d9e2-43fa-11e7-89fe-4d266d6b9996.png)
